### PR TITLE
feat(basic): add richer prototype helpers

### DIFF
--- a/packages/basic/__test__/array.test.ts
+++ b/packages/basic/__test__/array.test.ts
@@ -69,4 +69,51 @@ describe('arrayExtensions', () => {
     })
 
 
+    describe('distinct', () => {
+        it('应去除重复元素', () => {
+            expect([1, 1, 2, 3].distinct()).toEqual([1, 2, 3]);
+            expect(['a', 'a', 'b'].distinct()).toEqual(['a', 'b']);
+        });
+
+        it('应保持首次出现的顺序', () => {
+            expect([1, 2, 1, 3].distinct()).toEqual([1, 2, 3]);
+        });
+
+        it('引用类型元素应按引用比较', () => {
+            const obj = { id: 1 };
+            const arr = [obj, { id: 1 }, obj];
+            const distinct = arr.distinct();
+            expect(distinct).toEqual([obj, { id: 1 }]);
+            expect(distinct[0]).toBe(obj);
+            expect(distinct[1]).toBe(arr[1]);
+        });
+
+        it('this指向测试', () => {
+            const result = Array.prototype.distinct.call([1, 1, 2]);
+            expect(result).toEqual([1, 2]);
+        });
+    });
+
+    describe('chunk', () => {
+        it('应按照指定大小分组', () => {
+            expect([1, 2, 3, 4].chunk(2)).toEqual([[1, 2], [3, 4]]);
+            expect([1, 2, 3, 4, 5].chunk(2)).toEqual([[1, 2], [3, 4], [5]]);
+        });
+
+        it('小数大小应向下取整', () => {
+            expect([1, 2, 3].chunk(1.8)).toEqual([[1], [2], [3]]);
+        });
+
+        it('非正数大小应返回空数组', () => {
+            expect([1, 2, 3].chunk(0)).toEqual([]);
+            expect([1, 2, 3].chunk(-1)).toEqual([]);
+        });
+
+        it('this指向测试', () => {
+            const result = Array.prototype.chunk.call([1, 2, 3, 4], 3);
+            expect(result).toEqual([[1, 2, 3], [4]]);
+        });
+    });
+
+
 })

--- a/packages/basic/__test__/number.test.ts
+++ b/packages/basic/__test__/number.test.ts
@@ -293,6 +293,71 @@ describe('numberExtensions', () => {
             expect(Number.prototype.isEmpty.call('0' as any)).toBe(false); // 错误类型
         });
     });
+
+    describe('clamp', () => {
+        it('应限制在区间内', () => {
+            expect((5).clamp(1, 10)).toBe(5);
+            expect((0).clamp(-5, 5)).toBe(0);
+        });
+
+        it('小于下限应返回下限', () => {
+            expect((-10).clamp(-5, 5)).toBe(-5);
+        });
+
+        it('大于上限应返回上限', () => {
+            expect((10).clamp(-5, 5)).toBe(5);
+        });
+
+        it('边界顺序可自动调整', () => {
+            expect((2).clamp(5, 1)).toBe(2);
+            expect((0).clamp(5, -5)).toBe(0);
+        });
+
+        it('NaN边界应返回NaN', () => {
+            expect(Number.isNaN((1).clamp(NaN, 5))).toBe(true);
+            expect(Number.isNaN((1).clamp(0, NaN))).toBe(true);
+        });
+
+        it('this为NaN应返回NaN', () => {
+            expect(Number.isNaN((NaN).clamp(0, 1))).toBe(true);
+        });
+
+        it('应处理无穷值', () => {
+            expect((Infinity).clamp(0, 10)).toBe(10);
+            expect((-Infinity).clamp(-10, 10)).toBe(-10);
+        });
+    });
+
+    describe('isBetween', () => {
+        it('默认包含边界', () => {
+            expect((5).isBetween(1, 10)).toBe(true);
+            expect((1).isBetween(1, 10)).toBe(true);
+            expect((10).isBetween(1, 10)).toBe(true);
+        });
+
+        it('非包含比较', () => {
+            expect((5).isBetween(1, 10, false)).toBe(true);
+            expect((1).isBetween(1, 10, false)).toBe(false);
+            expect((10).isBetween(1, 10, false)).toBe(false);
+        });
+
+        it('边界顺序可调整', () => {
+            expect((5).isBetween(10, 1)).toBe(true);
+            expect((0).isBetween(5, -5)).toBe(true);
+        });
+
+        it('NaN应返回false', () => {
+            expect((NaN).isBetween(0, 1)).toBe(false);
+            expect((1).isBetween(NaN, 5)).toBe(false);
+            expect((1).isBetween(0, NaN)).toBe(false);
+        });
+
+        it('应处理无穷值', () => {
+            expect((Infinity).isBetween(0, Infinity)).toBe(true);
+            expect((-Infinity).isBetween(-Infinity, 0)).toBe(true);
+            expect((5).isBetween(-Infinity, Infinity, false)).toBe(true);
+        });
+    });
 })
 
 

--- a/packages/basic/__test__/string.test.ts
+++ b/packages/basic/__test__/string.test.ts
@@ -106,6 +106,57 @@ describe('stringExtensions', () => {
         });
     });
 
+    describe('contains', () => {
+        it('应正确判断包含关系', () => {
+            expect('hello'.contains('ell')).toBe(true);
+            expect('hello world'.contains('world')).toBe(true);
+            expect('typescript'.contains('script')).toBe(true);
+        });
+
+        it('应正确处理不存在的子串', () => {
+            expect('hello'.contains('abc')).toBe(false);
+            expect('memo'.contains('Memo')).toBe(false);
+        });
+
+        it('应处理非字符串参数', () => {
+            // @ts-ignore
+            expect('room42'.contains(42)).toBe(true);
+            // @ts-ignore
+            expect('boolean'.contains(true)).toBe(false);
+            // @ts-ignore
+            expect('null'.contains(null)).toBe(false);
+        });
+
+        it('this指向测试', () => {
+            expect(String.prototype.contains.call('hello', 'he')).toBe(true);
+            expect(String.prototype.contains.call('hello', 'HE')).toBe(false);
+        });
+    });
+
+    describe('equalsIgnoreCase', () => {
+        it('应在忽略大小写时返回true', () => {
+            expect('Hello'.equalsIgnoreCase('hello')).toBe(true);
+            expect('TypeScript'.equalsIgnoreCase('typescript')).toBe(true);
+        });
+
+        it('不同内容应返回false', () => {
+            expect('Hello'.equalsIgnoreCase('world')).toBe(false);
+            expect('abc'.equalsIgnoreCase('abd')).toBe(false);
+        });
+
+        it('非字符串参数应返回false', () => {
+            // @ts-ignore
+            expect('123'.equalsIgnoreCase(123)).toBe(false);
+            // @ts-ignore
+            expect('true'.equalsIgnoreCase(true)).toBe(false);
+        });
+
+        it('this指向测试', () => {
+            expect(String.prototype.equalsIgnoreCase.call('HELLO', 'hello')).toBe(true);
+            expect(String.prototype.equalsIgnoreCase.call('HELLO', 'HELLo')).toBe(true);
+        });
+    });
+
 
     describe('lastOrNull', () => {
         it('非空字符串应返回最后一个字符', () => {
@@ -236,6 +287,24 @@ describe('stringExtensions', () => {
             const longStr = 'a'.repeat(10000);
             expect(longStr.isNotEmpty()).toBe(true);
             expect(''.isNotEmpty()).toBe(false);
+        });
+    });
+
+    describe('isBlank', () => {
+        it('空白字符串应返回true', () => {
+            expect(''.isBlank()).toBe(true);
+            expect('   '.isBlank()).toBe(true);
+            expect('\t\n'.isBlank()).toBe(true);
+        });
+
+        it('含非空白字符应返回false', () => {
+            expect(' a '.isBlank()).toBe(false);
+            expect('text'.isBlank()).toBe(false);
+        });
+
+        it('this指向测试', () => {
+            expect(String.prototype.isBlank.call('   ')).toBe(true);
+            expect(String.prototype.isBlank.call(' 1 ')).toBe(false);
         });
     });
 })

--- a/packages/basic/array.d.ts
+++ b/packages/basic/array.d.ts
@@ -7,11 +7,20 @@
  */
 
 
-export interface ArrayExtensions extends BaseFuncCall<T[]>, Collection<T> {
+export interface ArrayExtensions<T> extends BaseFuncCall<T[]>, Collection<T> {
+    /**
+     * 获取去重后的数组
+     */
+    distinct(): T[];
+
+    /**
+     * 按指定大小分组
+     */
+    chunk(size: number): T[][];
 }
 
 declare global {
-    interface Array<T> extends ArrayExtensions {
+    interface Array<T> extends ArrayExtensions<T> {
     }
 }
 

--- a/packages/basic/number.d.ts
+++ b/packages/basic/number.d.ts
@@ -24,6 +24,16 @@ export interface NumberExtensions extends BaseFuncCall<number>, Comparable<numbe
     isNotZero(): boolean
 
     toDecimal(): import('decimal.js').Decimal
+
+    /**
+     * 将当前数值限制在指定区间
+     */
+    clamp(min: number, max: number): number
+
+    /**
+     * 判断当前数值是否处于区间内
+     */
+    isBetween(min: number, max: number, inclusive?: boolean): boolean
 }
 
 declare global {

--- a/packages/basic/src/array.ts
+++ b/packages/basic/src/array.ts
@@ -24,4 +24,24 @@ export function arrayExtensions() {
     Array.prototype.lastOrNull = function (this: unknown[]) {
         return this.length > 0 ? this[this.length - 1] : null
     }
+
+    /**
+     * 返回去重后的新数组
+     */
+    Array.prototype.distinct = function <T>(this: T[]) {
+        return Array.from(new Set(this))
+    }
+
+    /**
+     * 将数组按照指定大小切分
+     */
+    Array.prototype.chunk = function <T>(this: T[], size: number) {
+        if (!Number.isFinite(size) || size <= 0) return []
+        const chunkSize = Math.floor(size)
+        const result: T[][] = []
+        for (let index = 0; index < this.length; index += chunkSize) {
+            result.push(this.slice(index, index + chunkSize))
+        }
+        return result
+    }
 }

--- a/packages/basic/src/number.ts
+++ b/packages/basic/src/number.ts
@@ -59,4 +59,58 @@ export function numberExtensions() {
         return new Decimal(this.valueOf())
     }
 
+    /**
+     * 将当前数值限制在指定区间内
+     */
+    Number.prototype.clamp = function (this: Number, min: number, max: number) {
+        let lower = Number(min)
+        let upper = Number(max)
+        if (Number.isNaN(lower) || Number.isNaN(upper)) return Number.NaN
+        if (lower > upper) {
+            [lower, upper] = [upper, lower]
+        }
+
+        const rawValue = this.valueOf()
+        if (Number.isNaN(rawValue)) return Number.NaN
+
+        if (Number.isFinite(lower) && Number.isFinite(upper) && Number.isFinite(rawValue)) {
+            const value = new Decimal(rawValue)
+            if (value.lessThan(lower)) return lower
+            if (value.greaterThan(upper)) return upper
+            return value.toNumber()
+        }
+
+        if (rawValue < lower) return lower
+        if (rawValue > upper) return upper
+        return rawValue
+    }
+
+    /**
+     * 判断当前数值是否处于指定区间
+     */
+    Number.prototype.isBetween = function (this: Number, min: number, max: number, inclusive = true) {
+        let lower = Number(min)
+        let upper = Number(max)
+        if (Number.isNaN(lower) || Number.isNaN(upper)) return false
+        if (lower > upper) {
+            [lower, upper] = [upper, lower]
+        }
+
+        const rawValue = this.valueOf()
+        if (Number.isNaN(rawValue)) return false
+
+        if (Number.isFinite(lower) && Number.isFinite(upper) && Number.isFinite(rawValue)) {
+            const value = new Decimal(rawValue)
+            if (inclusive) {
+                return value.greaterThanOrEqualTo(lower) && value.lessThanOrEqualTo(upper)
+            }
+            return value.greaterThan(lower) && value.lessThan(upper)
+        }
+
+        if (inclusive) {
+            return rawValue >= lower && rawValue <= upper
+        }
+        return rawValue > lower && rawValue < upper
+    }
+
 }

--- a/packages/basic/src/string.ts
+++ b/packages/basic/src/string.ts
@@ -12,12 +12,36 @@ export function stringExtensions() {
         return diff === this
     }
 
+    /**
+     * 判断当前字符串是否包含给定的子串
+     */
+    String.prototype.contains = function (this: string, val: string | number | boolean) {
+        if (val === null || val === undefined) return false
+        const compare = typeof val === 'string' ? val : String(val)
+        return this.indexOf(compare) !== -1
+    }
+
+    /**
+     * 忽略大小写判断两个字符串是否相等
+     */
+    String.prototype.equalsIgnoreCase = function (this: string, val: unknown) {
+        if (typeof val !== 'string') return false
+        return this.toLocaleLowerCase() === val.toLocaleLowerCase()
+    }
+
     String.prototype.isEmpty = function () {
         return this.length === 0
     }
 
     String.prototype.isNotEmpty = function () {
         return !this.isEmpty()
+    }
+
+    /**
+     * 判断字符串是否由空白字符组成
+     */
+    String.prototype.isBlank = function () {
+        return this.trim().length === 0
     }
 
     String.prototype.firstOrNull = function () {

--- a/packages/basic/string.d.ts
+++ b/packages/basic/string.d.ts
@@ -6,7 +6,22 @@
  * @FilePath: /memo28.pro.Repo/packages/basic/string.d.ts
  */
 
-export interface StringExtensions extends BaseFuncCall<string>, Collection<string> {}
+export interface StringExtensions extends BaseFuncCall<string>, Collection<string> {
+    /**
+     * 判断是否包含指定子串
+     */
+    contains(substring: string): boolean;
+
+    /**
+     * 忽略大小写比较字符串是否相等
+     */
+    equalsIgnoreCase(val: string): boolean;
+
+    /**
+     * 判断字符串是否为空白
+     */
+    isBlank(): boolean;
+}
 
 declare global {
     interface String extends StringExtensions {


### PR DESCRIPTION
## Summary
- add convenience string helpers (`contains`, `equalsIgnoreCase`, `isBlank`) with inline docs and specs
- provide array utilities for distinct values and chunking, updating typings and coverage
- extend number helpers with clamp/range checks plus declaration updates and tests

## Testing
- pnpm --filter @memo28.pro/basic test

------
https://chatgpt.com/codex/tasks/task_e_68d1579ee67883309d96e9d3569e0d5f