### PR TITLE
docs: refresh package readmes

### DIFF
--- a/packages/basic/README.md
+++ b/packages/basic/README.md
@@ -1,240 +1,97 @@
 # @memo28.pro/basic
 
-一个强大的 JavaScript/TypeScript 原型扩展库，为原生类型提供便捷的扩展方法。
+> 原生 `String`、`Array`、`Object` 与 `Number` 的原型增强合集，提供一致的空值、安全访问与数值比较体验。
 
-## 📦 安装
+`@memo28.pro/basic` 通过可选的初始化函数为常用原生类型注入一组经过类型定义约束的实用方法。所有扩展都以 "少即是多" 为原则：避免污染命名空间、保持易读的调用方式，并在需要数值精度时由 `decimal.js` 提供支撑。
 
-```bash
-npm install @memo28.pro/basic
-# 或
-pnpm add @memo28.pro/basic
-# 或
-yarn add @memo28.pro/basic
+## 🎯 能力一览
+
+| 领域        | 能力聚焦 | 代表方法 |
+| ----------- | -------- | -------- |
+| 字符串 (String) | 空/空白判断、忽略大小写比较、安全访问 | `isEmpty()` · `isBlank()` · `equalsIgnoreCase()` · `firstOrNull()` |
+| 数组 (Array)    | 集合判空、包含判断、去重与切片       | `contains()` · `distinct()` · `chunk()` |
+| 对象 (Object)   | 空对象检测、安全取值、键存在性检查   | `isEmpty()` · `contains()` · `lastOrNull()` |
+| 数值 (Number)   | 可靠比较、区间约束、Decimal 精度包装 | `greaterThan()` · `isBetween()` · `clamp()` · `toDecimal()` |
+
+> 所有扩展方法都配套 `.d.ts` 声明文件 (`array.d.ts`、`number.d.ts` …)，确保在 TypeScript 项目中拥有完整的智能提示与类型检查体验。
+
+## 🧠 工作原理
+
+1. **显式引导**：使用者需主动调用 `stringExtensions()`、`arrayExtensions()`、`objectExtensions()`、`numberExtensions()` 等初始化函数，避免在未知上下文中静默扩展原型。
+2. **最小侵入**：每个扩展方法在挂载前都会先检查原型链，防止与宿主环境已有实现发生冲突。
+3. **数值可靠性**：所有比较相关方法内部统一通过 `Decimal` 封装浮点运算，既保证跨平台一致性，又保持返回布尔值的轻量接口。
+
+## 📁 目录结构
+
+```
+packages/basic
+├── src
+│   ├── array.ts        # Array 原型扩展
+│   ├── number.ts       # Number 原型扩展（Decimal 支持）
+│   ├── object.ts       # Object 原型扩展（键与可枚举检查）
+│   └── string.ts       # String 原型扩展
+├── *.d.ts              # 各原型扩展的类型声明文件
+├── __test__            # Vitest 单元测试
+└── tsdown.config.ts    # tsdown 构建配置
 ```
 
-## 🚀 快速开始
+## 🚀 快速上手
 
-```typescript
-import { stringExtensions, arrayExtensions, objectExtensions, numberExtensions } from '@memo28.pro/basic';
+```ts
+import {
+  stringExtensions,
+  arrayExtensions,
+  objectExtensions,
+  numberExtensions,
+} from '@memo28.pro/basic';
 
-// 初始化扩展方法
+// 在程序入口初始化（只需调用一次）
 stringExtensions();
 arrayExtensions();
 objectExtensions();
 numberExtensions();
 
-// 现在可以使用扩展方法了
-console.log('hello'.isEmpty()); // false
-console.log([1, 2, 3].firstOrNull()); // 1
-console.log({a: 1, b: 2}.lastOrNull()); // 2
-console.log((5).greaterThan(3)); // true
+'  '.isBlank();            // true
+[1, 1, 2].distinct();      // [1, 2]
+({ a: 1 }).contains('a');  // true
+(0.1).greaterThan(0.09);   // true（Decimal 支持）
 ```
 
-## 📚 API 文档
+### 常用模式
 
-### String 扩展
+- **安全访问**：通过 `firstOrNull()` / `lastOrNull()` 系列避免访问空集合抛错。
+- **语义化比较**：`isBetween()`、`clamp()` 帮助明确边界约束；`equalsIgnoreCase()` 面向用户输入。
+- **集合工具链**：`distinct()` 与 `chunk(size)` 组合实现快速数据预处理。
 
-#### 基础方法
-
-- **`eq(val: string | number): boolean`** - 比较字符串是否相等
-- **`isEmpty(): boolean`** - 检查字符串是否为空
-- **`isNotEmpty(): boolean`** - 检查字符串是否不为空
-- **`firstOrNull(): string | null`** - 安全获取第一个字符
-- **`lastOrNull(): string | null`** - 安全获取最后一个字符
-
-#### 使用示例
-
-```typescript
-// 字符串比较
-'hello'.eq('hello'); // true
-'123'.eq(123); // true
-
-// 空值检查
-''.isEmpty(); // true
-'hello'.isNotEmpty(); // true
-
-// 安全访问
-'hello'.firstOrNull(); // 'h'
-''.firstOrNull(); // null
-'world'.lastOrNull(); // 'd'
-```
-
-### Array 扩展
-
-#### 基础方法
-
-- **`eq(val: unknown[]): boolean`** - 比较数组引用是否相等
-- **`isEmpty(): boolean`** - 检查数组是否为空
-- **`isNotEmpty(): boolean`** - 检查数组是否不为空
-- **`contains(val: unknown): boolean`** - 检查数组是否包含指定元素
-- **`firstOrNull(): T | null`** - 安全获取第一个元素
-- **`lastOrNull(): T | null`** - 安全获取最后一个元素
-
-#### 使用示例
-
-```typescript
-const arr = [1, 2, 3];
-
-// 引用比较
-arr.eq(arr); // true
-arr.eq([1, 2, 3]); // false (不同引用)
-
-// 空值检查
-[].isEmpty(); // true
-[1, 2, 3].isNotEmpty(); // true
-
-// 包含检查
-[1, 2, 3].contains(2); // true
-[1, 2, 3].contains(4); // false
-
-// 安全访问
-[1, 2, 3].firstOrNull(); // 1
-[].firstOrNull(); // null
-[1, 2, 3].lastOrNull(); // 3
-```
-
-### Object 扩展
-
-#### 基础方法
-
-- **`eq(val: object): boolean`** - 比较对象引用是否相等
-- **`isEmpty(): boolean`** - 检查对象是否为空（无可枚举属性）
-- **`isNotEmpty(): boolean`** - 检查对象是否不为空
-- **`contains(key: PropertyKey): boolean`** - 检查对象是否包含指定属性
-- **`firstOrNull(): any | null`** - 安全获取第一个可枚举属性值
-- **`lastOrNull(): any | null`** - 安全获取最后一个可枚举属性值
-
-#### 使用示例
-
-```typescript
-const obj = { a: 1, b: 2, c: 3 };
-
-// 引用比较
-obj.eq(obj); // true
-obj.eq({ a: 1, b: 2, c: 3 }); // false (不同引用)
-
-// 空值检查
-{}.isEmpty(); // true
-{ a: 1 }.isNotEmpty(); // true
-
-// 属性检查
-obj.contains('a'); // true
-obj.contains('d'); // false
-
-// 安全访问
-obj.firstOrNull(); // 1
-{}.firstOrNull(); // null
-obj.lastOrNull(); // 3
-```
-
-### Number 扩展
-
-#### 基础方法
-
-- **`eq(val: number | string): boolean`** - 比较数值是否相等
-- **`isEmpty(): boolean`** - 检查数值是否为 0
-- **`isNotEmpty(): boolean`** - 检查数值是否不为 0
-- **`isZero(): boolean`** - 检查数值是否为 0
-- **`isNotZero(): boolean`** - 检查数值是否不为 0
-
-#### 比较方法（基于 Decimal.js 精确计算）
-
-- **`lessThan(diff: number): boolean`** - 小于比较
-- **`lessThanOrEqual(diff: number): boolean`** - 小于等于比较
-- **`greaterThan(diff: number): boolean`** - 大于比较
-- **`greaterThanOrEqual(diff: number): boolean`** - 大于等于比较
-
-#### 使用示例
-
-```typescript
-// 数值比较
-(5).eq(5); // true
-(5).eq('5'); // true
-
-// 零值检查
-(0).isEmpty(); // true
-(0).isZero(); // true
-(5).isNotZero(); // true
-
-// 精确比较（避免浮点数精度问题）
-(0.1).greaterThan(0.09); // true
-(0.2).lessThanOrEqual(0.3); // true
-(1.5).greaterThanOrEqual(1.5); // true
-```
-
-## 🏗️ 类型接口
-
-### BaseFuncCall<T>
-
-所有扩展类型的基础接口：
-
-```typescript
-interface BaseFuncCall<T> {
-  eq(val: T): boolean;
-  isEmpty(): boolean;
-  isNotEmpty(): boolean;
-}
-```
-
-### Collection<T>
-
-集合类型接口（String, Array, Object）：
-
-```typescript
-interface Collection<T> {
-  contains(item: T): boolean;
-  firstOrNull(): T | null;
-  lastOrNull(): T | null;
-}
-```
-
-### Comparable<T>
-
-可比较类型接口（Number）：
-
-```typescript
-interface Comparable<T> {
-  greaterThan(other: T): boolean;
-  greaterThanOrEqual(other: T): boolean;
-  lessThan(other: T): boolean;
-  lessThanOrEqual(other: T): boolean;
-}
-```
-
-## 🧪 测试
+## 🧪 开发与测试
 
 ```bash
-# 运行测试
-pnpm test
+# 在 monorepo 根目录执行
+pnpm install
 
-# 监听模式
-pnpm test:watch
+# 仅构建本包（CJS + ESM 输出在 dist/）
+pnpm --filter @memo28.pro/basic build
 
-# UI 模式
-pnpm test:ui
+# 运行/监听单元测试
+pnpm --filter @memo28.pro/basic test
+pnpm --filter @memo28.pro/basic test:watch
 ```
 
-## 📝 注意事项
+测试基于 [Vitest](https://vitest.dev/)，覆盖常见空值、比较与边界场景。构建工具使用 [tsdown](https://github.com/egoist/tsdown)，默认输出 CommonJS 与 ESM 双格式。
 
-1. **原型扩展**：此库通过扩展原生类型的原型来提供功能，请确保在项目初始化时调用相应的扩展函数。
+## 🔌 与其他包协作
 
-2. **类型安全**：所有扩展方法都提供了完整的 TypeScript 类型定义。
+- 作为多个项目的基础运行时补充模块使用，可在 `packages/*` 或应用层统一初始化。
+- 若搭配服务端渲染或外部 SDK，请确保仅初始化一次，避免重复挂载导致的性能损耗。
 
-3. **精确计算**：Number 扩展的比较方法使用 Decimal.js 来避免浮点数精度问题。
+## 🧱 扩展注意事项
 
-4. **引用比较**：`eq` 方法对于对象和数组进行的是引用比较，而不是深度比较。
-
-5. **空值安全**：`firstOrNull` 和 `lastOrNull` 方法在无法获取值时返回 `null`，避免抛出异常。
+- **命名约束**：在自定义扩展中遵循已有命名约定（`isXxx`、`firstOrNull` 等），便于搜索与阅读。
+- **幂等设计**：扩展函数内部使用 `Reflect.has` 检查，新增方法时应保持这种幂等策略。
+- **类型声明同步**：新增方法后务必同步更新对应的 `*.d.ts` 文件与测试用例。
 
 ## 📄 许可证
 
-[MIT License](LICENSE)
+本包基于 [ISC](https://opensource.org/licenses/ISC) 许可证发布。
 
-## 🤝 贡献
-
-欢迎提交 Issue 和 Pull Request！
-
-## 📞 联系
-
-- 作者：@memo28.repo
-- 项目地址：[GitHub](https://github.com/memo28-space-org/memo28.pro.Repo)
+如需了解更高层的使用案例，可参考 monorepo 内其他包对本模块的依赖方式。

--- a/packages/minio/README.md
+++ b/packages/minio/README.md
@@ -1,0 +1,144 @@
+# @memo28.pro/minio
+
+> 面向 MinIO/S3 兼容对象存储的轻量上传 SDK，聚焦“日记”（Diary）式内容的直传流程与自动建桶体验。
+
+该包抽象出一套 "上传器 (Uploader)" 协议，既可以直接复用内置的 `DirectUploader` 直连 MinIO，也可通过实现 `IDiaryUploader` 接口适配其他后端（HTTP API、云函数等）。`DiaryManager` 负责编排初始化、自动建桶与上传动作，确保调用方只需关注业务入参。
+
+## ✨ 能力概览
+
+- **自动建桶**：`automaticBucketBuilding` 会在上传前检测桶是否存在，不存在则自动创建。
+- **多策略上传**：通过 `IDiaryUploader` 接口可无缝切换直传、API 代理等不同策略。
+- **元数据支持**：`DiaryEntry` 支持附带 `ObjectMetaData`，方便记录自定义标签或 Content-Type。
+- **错误语义化**：统一返回 `[ErrorsNewResult | null, Payload]`，兼容 `@memo28/utils` 的错误处理方式。
+
+## 🧱 模块与职责
+
+| 组件 | 说明 |
+| --- | --- |
+| `DiaryEntry` | 描述一条上传任务，包括标题、内容、桶配置、可选文件/文件路径与对象元数据。|
+| `IDiaryUploader` | 上传器接口约束。定义 `init`、`automaticBucketBuilding`、`upload`、`list`、`get` 等能力。|
+| `DirectUploader` | MinIO 官方 SDK 的薄封装，负责直传、自动建桶、文件/字符串上传。|
+| `DiaryManager` | 对上传器的统一门面，提供依赖注入、初始化、上传等统一入口。|
+| `ApiUploader` |（预留）HTTP API 代理实现，当前以注释形式展示实现思路，可按需补充。|
+
+## 📁 目录结构
+
+```
+packages/minio
+├── src
+│   ├── core
+│   │   ├── diaryEntry.ts       # 上传载荷定义
+│   │   ├── iDiaryUploader.ts   # 上传器协议
+│   │   ├── directUploader.ts   # MinIO 直传实现
+│   │   ├── diaryManager.ts     # 管理器/门面
+│   │   └── apiUploader.ts      # API 模式示例（待扩展）
+│   └── index.ts                # 导出入口
+├── __test__
+│   └── diaryManager.test.ts    # Vitest 场景用例
+└── tsconfig.json
+```
+
+## 🚀 快速上手
+
+```ts
+import { DiaryManager, DirectUploader, DiaryEntry } from '@memo28.pro/minio';
+
+// 1. 初始化上传器
+const uploader = new DirectUploader();
+const manager = new DiaryManager(uploader);
+
+manager.init({
+  endPoint: '127.0.0.1',
+  port: 9000,
+  useSSL: false,
+  accessKey: 'admin',
+  secretKey: 'admin123',
+});
+
+// 2. 构建上传任务
+const entry = new DiaryEntry(
+  'report-2024-01-01.md',
+  '# 周报内容',
+  { bucketName: 'weekly-report', region: 'us-east-1' },
+);
+
+// 3. 自动建桶并上传
+await manager.automaticBucketBuilding(entry.bucketOptions.bucketName);
+const [err, result] = await manager.upload(entry);
+
+if (err) {
+  console.error('上传失败:', err.unWrap());
+} else {
+  console.log('上传成功:', result); // Partial<UploadedObjectInfo>
+}
+```
+
+### 上传文件流
+
+当需要上传本地文件时，可传入 `File`/`Blob` 对象及可选 `filePath`:
+
+```ts
+const file = new File([buffer], 'avatar.png');
+const entry = new DiaryEntry(
+  'avatar.png',
+  '',
+  { bucketName: 'user-asset' },
+  file,
+  undefined,
+  { 'Content-Type': 'image/png' }
+);
+await manager.upload(entry);
+```
+
+## 🧪 开发与测试
+
+```bash
+pnpm install
+
+# 类型编译 (tsc) + Vite 构建打包
+pnpm --filter @memo28.pro/minio build
+
+# 运行单元测试
+pnpm --filter @memo28.pro/minio test
+pnpm --filter @memo28.pro/minio test:watch
+```
+
+测试基于本地假定的 MinIO 配置（`127.0.0.1:9000`），请在需要时调整 `DiaryManager` 初始化参数，或在测试前启动本地 MinIO/Mock 服务。
+
+## 🧩 自定义上传策略
+
+实现 `IDiaryUploader` 便能扩展到任意后端：
+
+```ts
+import { IDiaryUploader, DiaryEntry } from '@memo28.pro/minio';
+import { Errors } from '@memo28/utils';
+
+class CloudFunctionUploader implements IDiaryUploader {
+  constructor(private endpoint: string) {}
+
+  async upload(entry: DiaryEntry) {
+    const res = await fetch(`${this.endpoint}/upload`, {
+      method: 'POST',
+      body: JSON.stringify(entry),
+    });
+    return res.ok
+      ? [null, await res.json()]
+      : [Errors.New(await res.text()), {}];
+  }
+
+  async list() { /* ... */ }
+  async get(id: string) { /* ... */ }
+}
+```
+
+将自定义上传器注入 `DiaryManager` 后即可使用，与内置实现共用调用链。
+
+## ⚠️ 注意事项
+
+- `automaticBucketBuilding` 使用 `bucketExists`/`makeBucket`，请确保调用方具备创建桶的权限。
+- 在 Node 环境中使用 `File` 需借助 `undici`、`node-fetch` 等提供的 `File` polyfill。
+- 返回值第二项为 `Partial<UploadedObjectInfo>`，如需完整响应可按需扩展 `DirectUploader`。
+
+## 📄 许可证
+
+本包遵循 ISC 许可证发布，欢迎按照业务需求扩展上传策略并提交 PR。

--- a/packages/notification/README.md
+++ b/packages/notification/README.md
@@ -1,271 +1,125 @@
-<!--
- * @Author: @memo28.repo
- * @Date: 2025-07-28 17:57:19
- * @LastEditTime: 2025-08-10 19:50:00
- * @Description: Notification SDK - 企业级消息通知解决方案
- * @FilePath: /memo28.pro.Repo/packages/notification/README.md
--->
-
 # @memo28.pro/notification
 
 [![npm version](https://badge.fury.io/js/@memo28.pro%2Fnotification.svg)](https://badge.fury.io/js/@memo28.pro%2Fnotification)
 [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org/)
 
-🚀 **企业级消息通知解决方案** - 支持多平台消息推送的轻量级 TypeScript SDK
+> 多渠道机器人通知的统一编排层，面向企业微信、飞书、钉钉等平台的插件化 TypeScript SDK。
 
-## ✨ 特性
+该包提供一个极简但可扩展的通知流水线：使用 `MessageBuilder` 构造消息、在 `Core` 中注册插件、由插件完成 Webhook 发送。设计重点在于**强类型、插件隔离与发送流程调试友好**，方便在企业内部服务或 DevOps 流水线中快速集成。
 
-- 🎯 **多平台支持**: 企业微信、飞书、钉钉等主流平台
-- 🔧 **插件化架构**: 易于扩展和自定义
-- 📝 **消息构建器**: 支持文本、Markdown 等多种格式
-- 🛡️ **类型安全**: 完整的 TypeScript 类型定义
-- ⚡ **轻量高效**: 零依赖，体积小巧
-- 🧪 **完整测试**: 单元测试和集成测试覆盖
+## ✨ 核心特性
 
-## 📦 安装
+- 🔌 **插件化平台适配**：通过继承 `Base`/`NotificationPlugin` 实现不同平台的发送逻辑。
+- 🧱 **消息构建 DSL**：`MessageBuilder` 支持文本与 Markdown，后续可按需扩展其他类型。
+- 🔁 **链式操作体验**：注册插件、播种消息、触发发送全流程链式调用，适合脚本化集成。
+- 🛡️ **类型安全**：所有公开 API 均为强类型定义，搭配 Vitest 用例保障运行时行为。
 
-```bash
-# npm
-npm install @memo28.pro/notification
+## 🧠 组件速览
 
-# yarn
-yarn add @memo28.pro/notification
+| 组件 | 角色 | 关键方法 |
+| ---- | ---- | -------- |
+| `Core` | 管理插件的中枢，负责注册、配置校验与批量发送 | `registerModule()` · `seed()` · `sendAll()` |
+| `MessageBuilder` | 消息构建器，基于 `MessageBuilderPayload` 提供 `setText`、`setMarkdown` 等链式 API | `create()` · `setText()` · `setMarkdown()` · `getMessages()` |
+| `Base` (`NotificationPlugin`) | 插件基类，封装 webhook、平台标识与消息构建器注入逻辑 | `setWebhook()` · `setPlatform()` · `setMessageBulder()` |
+| `Wxcom` | 企业微信实现示例，演示如何将 `MessageBuilder` 载荷转换为平台 API 需要的格式 | `send()` |
 
-# pnpm
-pnpm add @memo28.pro/notification
+> 目录：`src/core`（核心流程）· `src/message`（消息 DSL）· `src/plugin`（插件与基类）。
+
+## 📁 目录结构
+
+```
+packages/notification
+├── src
+│   ├── core/core.ts            # Core 类：插件注册、校验与批量发送
+│   ├── message/builder.ts      # 消息构建器，继承 builderPayload
+│   ├── message/builderPayload.ts
+│   ├── plugin/plugin.ts        # 插件抽象与基础实现
+│   └── plugin/wxCom.ts         # 企业微信插件示例
+├── __test__                    # Vitest 测试
+└── dist / tsdown.config.ts     # 构建输出与配置
 ```
 
 ## 🚀 快速开始
 
-### 基础用法
-
-```typescript
+```ts
 import { Core, MessageBuilder, Wxcom } from '@memo28.pro/notification';
 
-// 创建核心实例
 const core = new Core();
+const message = MessageBuilder.create()
+  .setText('🚀 部署完成')
+  .setMarkdown(`# 发布通知\\n- 版本: v1.0.0\\n- 状态: ✅`);
 
-// 创建消息构建器
-const msgBuilder = MessageBuilder.create()
-  .setText('🚀 Hello World!')
-  .setMarkdown('# 标题\n\n**粗体文本**');
+const wx = new Wxcom(process.env.WX_WEBHOOK!);
 
-// 创建企业微信插件
-const wxcomPlugin = new Wxcom('YOUR_WEBHOOK_URL');
+core.registerModule(wx)  // 支持传入数组注册多个插件
+    .seed(message);       // 注入消息构建器（自动完成配置校验）
 
-// 注册插件并发送消息
-core.registerModule(wxcomPlugin);
-core.seed(msgBuilder);
-
-// 发送消息
-const result = await wxcomPlugin.send();
-console.log('发送结果:', result);
+await core.sendAll();      // 逐个插件执行 send()
 ```
 
-### 高级用法
+### 发送流程
 
-```typescript
-import { Core, MessageBuilder, Wxcom } from '@memo28.pro/notification';
+1. **注册插件**：`registerModule` 接受单个或数组插件，内部统一维护 `moduleList`。
+2. **播种消息**：`seed` 会将 `MessageBuilder` 注入插件并执行基础配置检查（Webhook、平台标识、消息构建器是否齐全）。
+3. **执行发送**：调用 `sendAll` 时遍历插件，若插件实现 `send()` 即会被触发；失败会记录日志并返回 `false`。
 
-// 创建多个插件实例（发送到不同群组）
-const wxcomPlugin1 = new Wxcom('WEBHOOK_URL_1');
-const wxcomPlugin2 = new Wxcom('WEBHOOK_URL_2');
+## 🔌 扩展新平台
 
-// 构建复杂消息
-const msgBuilder = MessageBuilder.create()
-  .setText('📢 系统通知')
-  .setMarkdown(`
-# 📊 系统状态报告
-
-## 服务状态
-- **API服务**: ✅ 正常
-- **数据库**: ✅ 正常
-- **缓存**: ⚠️ 警告
-
-## 统计信息
-- 在线用户: **1,234**
-- 今日访问: **12,345**
-
----
-*报告时间: ${new Date().toLocaleString()}*
-  `)
-  .setText('📝 如有问题请及时处理');
-
-// 注册多个插件
-const core = new Core();
-core.registerModule([wxcomPlugin1, wxcomPlugin2]);
-core.seed(msgBuilder);
-
-// 批量发送
-const results = await Promise.all([
-  wxcomPlugin1.send(),
-  wxcomPlugin2.send()
-]);
-
-console.log('发送结果:', results);
-```
-
-## 📚 API 文档
-
-### Core 类
-
-核心管理类，负责插件注册和消息分发。
-
-```typescript
-class Core {
-  // 注册单个或多个插件
-  registerModule(module: Base | Base[]): void;
-  
-  // 播种消息到所有已注册的插件
-  seed(msgBuilder: MessageBuilder): void;
-  
-  // 获取已注册插件数量
-  getModuleCount(): number;
-}
-```
-
-### MessageBuilder 类
-
-消息构建器，支持链式调用构建多种格式的消息。
-
-```typescript
-class MessageBuilder {
-  // 创建新的消息构建器实例
-  static create(): MessageBuilder;
-  
-  // 添加文本消息
-  setText(text: string): MessageBuilder;
-  
-  // 添加 Markdown 消息
-  setMarkdown(markdown: string): MessageBuilder;
-  
-  // 获取消息数量
-  getMessageCount(): number;
-  
-  // 获取所有消息
-  getMessages(): MessageBuilderPayload[];
-  
-  // 清空所有消息
-  clear(): MessageBuilder;
-}
-```
-
-### Wxcom 类
-
-企业微信插件，实现企业微信 Webhook 消息发送。
-
-```typescript
-class Wxcom extends Base {
-  // 构造函数
-  constructor(webhook?: string);
-  
-  // 设置 Webhook 地址
-  setWebhook(webhook: string): void;
-  
-  // 发送消息
-  send(): Promise<boolean>;
-  
-  // 获取插件名称
-  getName(): string;
-}
-```
-
-## 🔌 插件开发
-
-你可以通过继承 `Base` 类来开发自定义插件：
-
-```typescript
+```ts
 import { Base, MessageBuilderPayload } from '@memo28.pro/notification';
 
-class CustomPlugin extends Base {
-  constructor(private config: any) {
+class MyPlatform extends Base {
+  constructor(webhook: string) {
     super();
+    this.setPlatform('my-platform');
+    this.setWebhook(webhook);
   }
-  
-  getName(): string {
-    return 'custom';
-  }
-  
+
   async send(): Promise<boolean> {
-    try {
-      // 获取消息列表
-      const messages = this.getMessages();
-      
-      // 实现你的发送逻辑
-      for (const message of messages) {
-        await this.sendMessage(message);
-      }
-      
-      return true;
-    } catch (error) {
-      console.error('发送失败:', error);
-      return false;
-    }
-  }
-  
-  private async sendMessage(message: MessageBuilderPayload): Promise<void> {
-    // 根据消息类型实现具体发送逻辑
-    switch (message.type) {
-      case 'text':
-        // 发送文本消息
-        break;
-      case 'markdown':
-        // 发送 Markdown 消息
-        break;
-    }
+    const payloads = this.getMessageBulder()?.getMessages() ?? [];
+    const res = await fetch(this.getWebhook(), {
+      method: 'POST',
+      body: JSON.stringify(payloads),
+    });
+    return res.ok;
   }
 }
 ```
 
-## 🧪 测试
+实现要点：
+
+- 保持 `setPlatform()` 返回唯一的平台标识，便于日志与监控；
+- 在 `send()` 内使用 `MessageBuilderPayload` 输出的消息数组，可按类型拆分并适配目标 API；
+- 如需额外配置（签名、代理等），可在插件构造函数中扩展参数并缓存到实例属性。
+
+## 🧪 开发与测试
 
 ```bash
-# 运行所有测试
-npm test
+pnpm install
 
-# 运行测试并监听文件变化
-npm run test:watch
+# 构建（通过 tsdown 输出 CJS + ESM）
+pnpm --filter @memo28.pro/notification build
 
-# 运行测试 UI
-npm run test:ui
+# 运行测试
+pnpm --filter @memo28.pro/notification test
+pnpm --filter @memo28.pro/notification test:watch
 ```
 
-## 📋 系统架构
+Vitest 测试覆盖消息构建、插件注入和发送流程的关键路径，可作为新增插件时的参考模版。
 
-```mermaid
-graph TD
-    A[Core SDK] --> B[Plugin Adapter]
-    B --> C[WeCom Plugin]
-    B --> D[Lark/Feishu Plugin]
-    B --> E[Custom Plugin]
-    A --> F[Message Builder]
-    A --> G[Token Manager]
-    A --> H[Error Handler]
-```
+## 🛠️ 调试建议
 
-## 🤝 贡献
+- **Webhook 校验**：`Core.seed` 会输出缺失 Webhook 或平台标识的警告，可借此快速定位配置问题。
+- **多渠道并发**：`core.sendAll()` 默认串行执行，如需并行可在业务侧自行 `Promise.all` 对插件逐个调用 `send()`。
+- **网络调试**：`Wxcom.send()` 内部使用 `fetch`，可通过 `global.fetch = ...` 注入自定义实现或结合 Vite/Vitest 的 `vi.spyOn` 进行断言。
 
-欢迎提交 Issue 和 Pull Request！
+## 🤝 贡献指南
 
-1. Fork 本仓库
-2. 创建你的特性分支 (`git checkout -b feature/AmazingFeature`)
-3. 提交你的修改 (`git commit -m 'Add some AmazingFeature'`)
-4. 推送到分支 (`git push origin feature/AmazingFeature`)
-5. 打开一个 Pull Request
+1. Fork 仓库并创建特性分支。
+2. 为新增能力补充 Vitest 用例与类型声明。
+3. 通过 `pnpm --filter @memo28.pro/notification build` 和 `test` 校验无误后提交 PR。
 
 ## 📄 许可证
 
-本项目采用 [ISC](https://opensource.org/licenses/ISC) 许可证。
-
-## 🔗 相关链接
-
-- [企业微信机器人文档](https://developer.work.weixin.qq.com/document/path/91770)
-- [飞书机器人文档](https://open.feishu.cn/document/ukTMukTMukTM/ucTM5YjL3ETO24yNxkjN)
-- [钉钉机器人文档](https://developers.dingtalk.com/document/app/custom-robot-access)
-
----
-
-<p align="center">
-  Made with ❤️ by <a href="https://github.com/memo28">@memo28.repo</a>
-</p>
+本包以 ISC 协议开源，可自由在企业与个人项目中使用与修改。


### PR DESCRIPTION
## Summary
- rewrite the @memo28.pro/basic README to emphasise developer workflows, extension inventory and prototype usage patterns
- add a new README for @memo28.pro/minio covering architecture, quick-start examples and custom uploader guidance
- overhaul the @memo28.pro/notification README to focus on core components, extensibility and debugging tips

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d15df9e8ec8330be16ab718151154a