### PR TITLE
feat: add Optional support to basic package

### DIFF
--- a/packages/basic/README.md
+++ b/packages/basic/README.md
@@ -14,6 +14,7 @@
 | 数组 (Array)    | 集合判空、包含判断、去重与切片       | `contains()` · `distinct()` · `chunk()` |
 | 对象 (Object)   | 空对象检测、安全取值、键存在性检查   | `isEmpty()` · `contains()` · `lastOrNull()` |
 | 数值 (Number)   | 可靠比较、区间约束、Decimal 精度包装 | `greaterThan()` · `isBetween()` · `clamp()` · `toDecimal()` |
+| 可选值 (Optional) | Java 风格的安全值包装、链式判空与回退 | `Optional.of()` · `map()` · `orElseGet()` · `ifPresentOrElse()` |
 
 > 所有扩展方法都配套 `.d.ts` 声明文件 (`array.d.ts`、`number.d.ts` …)，确保在 TypeScript 项目中拥有完整的智能提示与类型检查体验。
 
@@ -45,6 +46,7 @@ import {
   arrayExtensions,
   objectExtensions,
   numberExtensions,
+  optionalExtensions,
 } from '@memo28.pro/basic';
 
 // 在程序入口初始化（只需调用一次）
@@ -52,11 +54,13 @@ stringExtensions();
 arrayExtensions();
 objectExtensions();
 numberExtensions();
+optionalExtensions();
 
 '  '.isBlank();            // true
 [1, 1, 2].distinct();      // [1, 2]
 ({ a: 1 }).contains('a');  // true
 (0.1).greaterThan(0.09);   // true（Decimal 支持）
+Optional.ofNullable(user?.email).map(v => v.trim()).orElse(''); // 安全读取并降噪
 ```
 
 ### 常用模式
@@ -64,6 +68,17 @@ numberExtensions();
 - **安全访问**：通过 `firstOrNull()` / `lastOrNull()` 系列避免访问空集合抛错。
 - **语义化比较**：`isBetween()`、`clamp()` 帮助明确边界约束；`equalsIgnoreCase()` 面向用户输入。
 - **集合工具链**：`distinct()` 与 `chunk(size)` 组合实现快速数据预处理。
+- **可选值包装**：`Optional.ofNullable()` 将链式调用里的空值风险收束在同一个 API 内，配合 `map()`、`flatMap()` 与 `orElseGet()` 可以覆盖“值加工、缺省回退、延迟求值”等常见路径。
+
+### Optional 方法速览
+
+- `Optional.of(value)`：传入的值不可为空，空值会抛出错误，适合明确存在的场景。
+- `Optional.ofNullable(value)`：接受可能为空的值，空值将得到共享的 `empty` 实例。
+- `map(fn)` / `flatMap(fn)`：在不解包的前提下加工数据，`flatMap` 需要返回 `Optional` 实例。
+- `filter(predicate)`：条件不满足时自动回退为空，可用于链式判定。
+- `orElse(value)` / `orElseGet(fn)`：为缺省场景提供静态或惰性默认值。
+- `ifPresent(consumer)` / `ifPresentOrElse(consumer, emptyAction)`：聚焦副作用或分支处理。
+- `toNullable()`：将 `Optional` 中的值转换回 `null`/具体值，便于与旧代码衔接。
 
 
 ## 🧪 开发与测试

--- a/packages/basic/__test__/globalSetup.ts
+++ b/packages/basic/__test__/globalSetup.ts
@@ -1,5 +1,5 @@
 // 初始化扩展方法
-import {stringExtensions, objectExtensions, arrayExtensions, numberExtensions} from '../src';
+import {stringExtensions, objectExtensions, arrayExtensions, numberExtensions, optionalExtensions} from '../src';
 import {beforeAll, afterAll} from 'vitest'
 
 // 保存原始原型方法
@@ -10,11 +10,14 @@ const originalPrototypes = {
     object: {...Object.prototype},
 };
 
+const originalGlobalOptional = (globalThis as typeof globalThis & {Optional?: unknown}).Optional;
+
 beforeAll(() => {
     stringExtensions();
     arrayExtensions();
     numberExtensions();
     objectExtensions();
+    optionalExtensions();
 });
 
 afterAll(() => {
@@ -23,6 +26,13 @@ afterAll(() => {
     Object.assign(Array.prototype, originalPrototypes.array);
     Object.assign(Number.prototype, originalPrototypes.number);
     Object.assign(Object.prototype, originalPrototypes.object);
+
+    if (originalGlobalOptional === undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete (globalThis as typeof globalThis & {Optional?: unknown}).Optional;
+    } else {
+        (globalThis as typeof globalThis & {Optional?: unknown}).Optional = originalGlobalOptional;
+    }
 });
 
 // // 处理第三方库冲突

--- a/packages/basic/__test__/optional.test.ts
+++ b/packages/basic/__test__/optional.test.ts
@@ -1,0 +1,103 @@
+import {describe, it, expect, vi} from 'vitest'
+import './globalSetup'
+import {Optional, optionalExtensions} from '../src'
+
+describe('Optional 可选值工具', () => {
+    it('of 应拒绝空值并抛出友好错误', () => {
+        expect(() => Optional.of(null as any)).toThrowError(/不接受 null/)
+        expect(() => Optional.of(undefined as any)).toThrowError(/不接受 null/)
+    })
+
+    it('ofNullable 应正确构建空与非空实例', () => {
+        const nonEmpty = Optional.ofNullable('test')
+        const emptyOpt = Optional.ofNullable(undefined)
+
+        expect(nonEmpty.isPresent()).toBe(true)
+        expect(nonEmpty.get()).toBe('test')
+        expect(emptyOpt.isEmpty()).toBe(true)
+        expect(() => emptyOpt.get()).toThrowError(/Optional 为空/)
+    })
+
+    it('map 与 filter 应保持链式语义', () => {
+        const result = Optional.of(2)
+            .filter(v => v > 1)
+            .map(v => v * 2)
+            .map(v => v.toString())
+
+        expect(result.isPresent()).toBe(true)
+        expect(result.get()).toBe('4')
+
+        const filteredOut = Optional.of(1).filter(v => v > 10)
+        expect(filteredOut.isEmpty()).toBe(true)
+    })
+
+    it('flatMap 应校验返回值类型', () => {
+        const doubled = Optional.of(3).flatMap(v => Optional.of(v * 2))
+        expect(doubled.get()).toBe(6)
+
+        const invalid = () => Optional.of(1).flatMap(() => 123 as any)
+        expect(invalid).toThrowError(/Optional 实例/)
+    })
+
+    it('orElse 与 orElseGet 应提供回退值', () => {
+        const value = Optional.ofNullable<number>(null)
+        expect(value.orElse(10)).toBe(10)
+
+        const supplier = vi.fn(() => 20)
+        expect(value.orElseGet(supplier)).toBe(20)
+        expect(supplier).toHaveBeenCalledTimes(1)
+    })
+
+    it('orElseThrow 应抛出自定义错误', () => {
+        const errorOpt = Optional.empty<string>()
+        expect(() => errorOpt.orElseThrow(() => new TypeError('缺少值'))).toThrow(TypeError)
+
+        const defaultError = Optional.empty<string>()
+        expect(() => defaultError.orElseThrow()).toThrowError(/没有可用的值/)
+    })
+
+    it('or 应在缺失值时调用 supplier', () => {
+        const fallback = Optional.empty<number>().or(() => Optional.of(42))
+        expect(fallback.get()).toBe(42)
+
+        const invalid = () => Optional.empty<number>().or(() => 1 as any)
+        expect(invalid).toThrowError(/返回 Optional 实例/)
+    })
+
+    it('ifPresent 与 ifPresentOrElse 应正确处理分支', () => {
+        const consumer = vi.fn()
+        Optional.of('hi').ifPresent(consumer)
+        expect(consumer).toHaveBeenCalledWith('hi')
+
+        const fallback = vi.fn()
+        Optional.empty<string>().ifPresentOrElse(consumer, fallback)
+        expect(fallback).toHaveBeenCalledTimes(1)
+    })
+
+    it('toNullable 应方便地回退到 null', () => {
+        expect(Optional.of('abc').toNullable()).toBe('abc')
+        expect(Optional.empty<string>().toNullable()).toBeNull()
+    })
+
+    it('empty 应返回同一个共享实例', () => {
+        const a = Optional.empty<number>()
+        const b = Optional.empty<number>()
+        expect(a).toBe(b)
+    })
+
+    it('已有 Optional 时应复用原实现并给出提示', () => {
+        class LegacyOptional {}
+        const globalScope = globalThis as typeof globalThis & {Optional?: unknown}
+        const previous = globalScope.Optional
+        globalScope.Optional = LegacyOptional as any
+
+        try {
+            const reused = optionalExtensions()
+            expect(reused).toBe(LegacyOptional)
+            expect(globalScope.Optional).toBe(LegacyOptional)
+        } finally {
+            globalScope.Optional = previous
+            optionalExtensions() // 恢复为本包的实现，避免其他用例受影响
+        }
+    })
+})

--- a/packages/basic/all.d.ts
+++ b/packages/basic/all.d.ts
@@ -4,3 +4,4 @@
 /// <reference path="./number.d.ts" />
 /// <reference path="./object.d.ts" />
 /// <reference path="./string.d.ts" />
+/// <reference path="./optional.d.ts" />

--- a/packages/basic/optional.d.ts
+++ b/packages/basic/optional.d.ts
@@ -1,0 +1,77 @@
+export declare class Optional<T> {
+    private readonly inner;
+    private static readonly EMPTY;
+    private constructor();
+    /**
+     * 创建一个不可为空的 Optional，如果传入 null/undefined 会抛出异常。
+     */
+    static of<T>(value: T): Optional<NonNullable<T>>;
+    /**
+     * 创建一个允许为空的 Optional，传入 null/undefined 将得到 EMPTY 实例。
+     */
+    static ofNullable<T>(value: T): Optional<NonNullable<T>>;
+    /**
+     * 返回共享的空实例，减少对象创建开销。
+     */
+    static empty<T = never>(): Optional<T>;
+    /**
+     * 当前是否存在有效值。
+     */
+    isPresent(): this is Optional<NonNullable<T>>;
+    /**
+     * 当前是否为空。
+     */
+    isEmpty(): boolean;
+    /**
+     * 直接获取值，若为空将抛出错误。
+     */
+    get(): T;
+    /**
+     * 当存在值时执行回调。
+     */
+    ifPresent(consumer: (value: T) => void): this;
+    /**
+     * 当存在值时执行 consumer，否则执行 emptyAction。
+     */
+    ifPresentOrElse(consumer: (value: T) => void, emptyAction: () => void): this;
+    /**
+     * 若当前为空直接返回自身；否则根据谓词过滤，条件不满足返回 EMPTY。
+     */
+    filter(predicate: (value: T) => boolean): Optional<T>;
+    /**
+     * 映射值并包装为 Optional，映射结果为 null/undefined 时将返回 EMPTY。
+     */
+    map<U>(mapper: (value: T) => U): Optional<NonNullable<U>>;
+    /**
+     * 使用返回 Optional 的映射函数，便于串联多个 Optional 操作。
+     */
+    flatMap<U>(mapper: (value: T) => Optional<U>): Optional<U>;
+    /**
+     * 若存在值则返回该值，否则返回提供的默认值。
+     */
+    orElse(other: T): T;
+    /**
+     * 若存在值则返回该值，否则调用 supplier 获取默认值。
+     */
+    orElseGet(supplier: () => T): T;
+    /**
+     * 若存在值则返回该值，否则抛出指定错误（或默认错误）。
+     */
+    orElseThrow(errorSupplier?: () => unknown): T;
+    /**
+     * 若为空则调用 supplier 返回新的 Optional，否则返回自身。
+     */
+    or(supplier: () => Optional<T>): Optional<T>;
+    /**
+     * 将值转换为可空类型，便于与旧逻辑衔接。
+     */
+    toNullable(): T | null;
+}
+export declare function optionalExtensions(): typeof Optional;
+
+declare global {
+    // 使用 var 以便与浏览器 / Node 的全局对象兼容
+    var Optional: typeof Optional | undefined;
+}
+
+export {}

--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -33,6 +33,7 @@
     "number.d.ts",
     "object.d.ts",
     "string.d.ts",
+    "optional.d.ts",
     "all.d.ts"
   ],
   "author": "",

--- a/packages/basic/src/index.ts
+++ b/packages/basic/src/index.ts
@@ -9,3 +9,4 @@ export {numberExtensions} from './number';
 export {stringExtensions} from './string'
 export {objectExtensions} from './object'
 export {arrayExtensions} from './array'
+export {optionalExtensions, Optional} from './optional'

--- a/packages/basic/src/optional.ts
+++ b/packages/basic/src/optional.ts
@@ -1,0 +1,172 @@
+/**
+ * Optional 类的实现，借鉴了 Java Optional 的常见行为。
+ *
+ * - 通过 optionalExtensions 将 Optional 安装到全局，避免重复挂载。
+ * - 若宿主环境已存在 Optional，会打印提示并复用原有实现。
+ * - 所有方法都尽量保持无副作用，并在必要时抛出明确的错误，便于排查。
+ */
+export class Optional<T> {
+    private static readonly EMPTY = new Optional<never>(undefined)
+
+    private constructor(private readonly inner: T | null | undefined) {}
+
+    /**
+     * 创建一个不可为空的 Optional，如果传入 null/undefined 会抛出异常。
+     */
+    static of<T>(value: T): Optional<NonNullable<T>> {
+        if (value === null || value === undefined) {
+            throw new TypeError('Optional.of() 不接受 null 或 undefined 值')
+        }
+        return new Optional(value as NonNullable<T>)
+    }
+
+    /**
+     * 创建一个允许为空的 Optional，传入 null/undefined 将得到 EMPTY 实例。
+     */
+    static ofNullable<T>(value: T): Optional<NonNullable<T>> {
+        if (value === null || value === undefined) return Optional.empty()
+        return new Optional(value as NonNullable<T>)
+    }
+
+    /**
+     * 返回共享的空实例，减少对象创建开销。
+     */
+    static empty<T = never>(): Optional<T> {
+        return Optional.EMPTY as Optional<T>
+    }
+
+    /**
+     * 当前是否存在有效值。
+     */
+    isPresent(): this is Optional<NonNullable<T>> {
+        return this.inner !== null && this.inner !== undefined
+    }
+
+    /**
+     * 当前是否为空。
+     */
+    isEmpty(): boolean {
+        return !this.isPresent()
+    }
+
+    /**
+     * 直接获取值，若为空将抛出错误。
+     */
+    get(): T {
+        if (!this.isPresent()) {
+            throw new Error('Optional 为空，无法调用 get()')
+        }
+        return this.inner as T
+    }
+
+    /**
+     * 当存在值时执行回调。
+     */
+    ifPresent(consumer: (value: T) => void): this {
+        if (this.isPresent()) {
+            consumer(this.inner as T)
+        }
+        return this
+    }
+
+    /**
+     * 当存在值时执行 consumer，否则执行 emptyAction。
+     */
+    ifPresentOrElse(consumer: (value: T) => void, emptyAction: () => void): this {
+        if (this.isPresent()) {
+            consumer(this.inner as T)
+        } else {
+            emptyAction()
+        }
+        return this
+    }
+
+    /**
+     * 若当前为空直接返回自身；否则根据谓词过滤，条件不满足返回 EMPTY。
+     */
+    filter(predicate: (value: T) => boolean): Optional<T> {
+        if (!this.isPresent()) return this
+        return predicate(this.inner as T) ? this : Optional.empty()
+    }
+
+    /**
+     * 映射值并包装为 Optional，映射结果为 null/undefined 时将返回 EMPTY。
+     */
+    map<U>(mapper: (value: T) => U): Optional<NonNullable<U>> {
+        if (!this.isPresent()) return Optional.empty()
+        return Optional.ofNullable(mapper(this.inner as T))
+    }
+
+    /**
+     * 使用返回 Optional 的映射函数，便于串联多个 Optional 操作。
+     */
+    flatMap<U>(mapper: (value: T) => Optional<U>): Optional<U> {
+        if (!this.isPresent()) return Optional.empty()
+        const result = mapper(this.inner as T)
+        if (!(result instanceof Optional)) {
+            throw new TypeError('flatMap 期望返回 Optional 实例')
+        }
+        return result
+    }
+
+    /**
+     * 若存在值则返回该值，否则返回提供的默认值。
+     */
+    orElse(other: T): T {
+        return this.isPresent() ? (this.inner as T) : other
+    }
+
+    /**
+     * 若存在值则返回该值，否则调用 supplier 获取默认值。
+     */
+    orElseGet(supplier: () => T): T {
+        return this.isPresent() ? (this.inner as T) : supplier()
+    }
+
+    /**
+     * 若存在值则返回该值，否则抛出指定错误（或默认错误）。
+     */
+    orElseThrow(errorSupplier?: () => unknown): T {
+        if (this.isPresent()) return this.inner as T
+        if (errorSupplier) {
+            const reason = errorSupplier()
+            if (reason instanceof Error) throw reason
+            throw new Error(String(reason))
+        }
+        throw new Error('Optional 为空，没有可用的值')
+    }
+
+    /**
+     * 若为空则调用 supplier 返回新的 Optional，否则返回自身。
+     */
+    or(supplier: () => Optional<T>): Optional<T> {
+        if (this.isPresent()) return this
+        const fallback = supplier()
+        if (!(fallback instanceof Optional)) {
+            throw new TypeError('or 期望 supplier 返回 Optional 实例')
+        }
+        return fallback
+    }
+
+    /**
+     * 将值转换为可空类型，便于与旧逻辑衔接。
+     */
+    toNullable(): T | null {
+        return this.isPresent() ? (this.inner as T) : null
+    }
+}
+
+/**
+ * 将 Optional 安装到全局作用域，若已有实现则复用并输出提示。
+ */
+export function optionalExtensions() {
+    const globalScope = globalThis as typeof globalThis & {Optional?: typeof Optional}
+
+    if (Reflect.has(globalScope, 'Optional')) {
+        console.warn('[basic] 检测到宿主已存在 Optional，将复用现有实现')
+        return globalScope.Optional as typeof Optional
+    }
+
+    globalScope.Optional = Optional
+    return Optional
+}


### PR DESCRIPTION
## Summary
- implement a Java-style Optional helper with global installer and guards against existing hosts
- export Optional from the basic package with updated type declarations and documentation
- add comprehensive Optional-focused tests covering edge cases and global reuse scenarios

## Testing
- pnpm --filter @memo28.pro/basic test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940cea7fa688330818455e6f384eaa6)